### PR TITLE
Backport fix for kubernetes in-cluster CNAME lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,13 @@ pb:
 linter:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install golint
-	gometalinter --deadline=2m --disable-all --enable=gofmt --enable=golint --enable=vet --vendor --exclude=^pb/ ./...
+	gometalinter --deadline=10m --disable-all --enable=gofmt --enable=golint --enable=vet --vendor --exclude=^pb/ ./...
 
 .PHONY: goimports
 goimports:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install goimports
-	( gometalinter --deadline=2m --disable-all --enable=goimports --vendor --exclude=^pb/ ./... || true )
+	( gometalinter --deadline=10m --disable-all --enable=goimports --vendor --exclude=^pb/ ./... || true )
 
 # Presubmit runs all scripts in .presubmit; any non 0 exit code will fail the build.
 .PHONY: presubmit

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -182,6 +182,15 @@ var dnsTestCases = []test.Case{
 			test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
 		},
 	},
+	// CNAME External To Internal Service
+	{
+		Qname: "external-to-service.testns.svc.cluster.local", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("external-to-service.testns.svc.cluster.local.	5	IN	CNAME	svc1.testns.svc.cluster.local."),
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
 	// AAAA Service (with an existing A record, but no AAAA record)
 	{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
@@ -408,6 +417,21 @@ var svcIndex = map[string][]*api.Service{
 		},
 		Spec: api.ServiceSpec{
 			ExternalName: "ext.interwebs.test",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
+			Type: api.ServiceTypeExternalName,
+		},
+	}},
+	"external-to-service.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "external-to-service",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ExternalName: "svc1.testns.svc.cluster.local.",
 			Ports: []api.ServicePort{{
 				Name:     "http",
 				Protocol: "tcp",

--- a/plugin/kubernetes/parse_test.go
+++ b/plugin/kubernetes/parse_test.go
@@ -14,17 +14,17 @@ func TestParseRequest(t *testing.T) {
 		expected string // output from r.String()
 	}{
 		// valid SRV request
-		{"_http._tcp.webs.mynamespace.svc.inter.webs.test.", "http.tcp..webs.mynamespace.svc"},
+		{"_http._tcp.webs.mynamespace.svc.inter.webs.tests.", "http.tcp..webs.mynamespace.svc"},
 		// wildcard acceptance
-		{"*.any.*.any.svc.inter.webs.test.", "*.any..*.any.svc"},
+		{"*.any.*.any.svc.inter.webs.tests.", "*.any..*.any.svc"},
 		// A request of endpoint
-		{"1-2-3-4.webs.mynamespace.svc.inter.webs.test.", "*.*.1-2-3-4.webs.mynamespace.svc"},
+		{"1-2-3-4.webs.mynamespace.svc.inter.webs.tests.", "*.*.1-2-3-4.webs.mynamespace.svc"},
 		// bare zone
-		{"inter.webs.test.", "....."},
+		{"inter.webs.tests.", "....."},
 		// bare svc type
-		{"svc.inter.webs.test.", "....."},
+		{"svc.inter.webs.tests.", "....."},
 		// bare pod type
-		{"pod.inter.webs.test.", "....."},
+		{"pod.inter.webs.tests.", "....."},
 	}
 	for i, tc := range tests {
 		m := new(dns.Msg)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This backports coredns/coredns#2040 which fixes coredns/coredns#2038 . Without this PR, Kubernetes ExternalName Services that reference in-cluster domains cannot resolve. More concretely, this breaks Knative Eventing on OpenShift 4. The upstream coredns bug has been fixed for some time.

### 2. Which issues (if any) are related?

See above.

### 3. Which documentation changes (if any) need to be made?

:shrug: - If we track release notes for this components, it may be worth calling out this fix explicitly. I did not hit similar issues in OpenShift 3.11 and as 4.0 isn't GA yet that may not be needed. 