### PR TITLE
WIP: plugin: Add mdns plugin

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -36,6 +36,7 @@ dnstap:dnstap
 chaos:chaos
 loadbalance:loadbalance
 cache:cache
+mdns:github.com/openshift-metal3/coredns-mdns
 rewrite:rewrite
 dnssec:dnssec
 autopath:autopath


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The Metal3 project uses mDNS to enable a zeroconf DNS solution for OpenShift on BareMetal.

This plugin provides a responder that will serve mDNS records that it can browse. Pulling in as an external plugin.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
