### PR TITLE
Update coredns-mdns vendoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/infobloxopen/go-trees v0.0.0-20190313150506-2af4e13f9062
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/miekg/dns v1.1.25
-	github.com/openshift/coredns-mdns v0.0.0-20200220182154-b0f03279ed06
+	github.com/openshift/coredns-mdns v0.0.0-20200302154045-ff66ed9a4619
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/openshift/coredns-mdns v0.0.0-20200122115902-259b209eea6a h1:twcIn3o9
 github.com/openshift/coredns-mdns v0.0.0-20200122115902-259b209eea6a/go.mod h1:BLITL6gPQ/ou0UMHoA3YvFdAoh2UsV/YNgA7Sx9DMz4=
 github.com/openshift/coredns-mdns v0.0.0-20200220182154-b0f03279ed06 h1:PQ4ATq5VDIBB/tdoBiZiZqXSUHETUDjR4Eq5qB+aFfY=
 github.com/openshift/coredns-mdns v0.0.0-20200220182154-b0f03279ed06/go.mod h1:BLITL6gPQ/ou0UMHoA3YvFdAoh2UsV/YNgA7Sx9DMz4=
+github.com/openshift/coredns-mdns v0.0.0-20200302154045-ff66ed9a4619 h1:ivr7CJlVLQl3cDJiXAqJmNM2Lmt/WsBwLtoGnThp0OM=
+github.com/openshift/coredns-mdns v0.0.0-20200302154045-ff66ed9a4619/go.mod h1:BLITL6gPQ/ou0UMHoA3YvFdAoh2UsV/YNgA7Sx9DMz4=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=

--- a/vendor/github.com/openshift/coredns-mdns/mdns.go
+++ b/vendor/github.com/openshift/coredns-mdns/mdns.go
@@ -195,7 +195,7 @@ func (m *MDNS) BrowseMDNS() {
 	for k, v := range cnames {
 		(*m.cnames)[k] = v
 	}
-	log.Debugf("mdnsHosts: %v", m.mdnsHosts)
+	log.Infof("mdnsHosts: %v", m.mdnsHosts)
 	for name, entry := range *m.mdnsHosts {
 		log.Debugf("%s: %v", name, entry)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -170,7 +170,7 @@ github.com/mitchellh/go-homedir
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openshift/coredns-mdns v0.0.0-20200220182154-b0f03279ed06
+# github.com/openshift/coredns-mdns v0.0.0-20200302154045-ff66ed9a4619
 github.com/openshift/coredns-mdns
 # github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492
 github.com/opentracing-contrib/go-observer


### PR DESCRIPTION
This just pulls in a logging change so that it is possible to tell
if the mdns plugin is working without enabling full debug logging.
