### PR TITLE
OWNERS: Add component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,8 @@ approvers:
   - danehans
   - Miciah
 
+component: DNS
+
 features:
   - comments
   - reviewers


### PR DESCRIPTION
* `OWNERS`: Add component.


----

# 

### 1. Why is this pull request needed and what does it do?

Any OpenShift GitHub repository which contributes directly to the product should specify the associated Bugzilla component in the `OWNERS` file in the root of the default branch of the repository.

### 2. Which issues (if any) are related?

By decree of the ART team.

### 3. Which documentation changes (if any) need to be made?

None other than the `OWNERS` file itself.

### 4. Does this introduce a backward incompatible change or deprecation?

No.