### PR TITLE
Add bugzilla component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,3 +21,5 @@ aliases:
     /wai -> /label add: works as intended
   - |
     /release: (.*) -> /exec: /opt/bin/release-coredns $1
+
+component: "DNS"


### PR DESCRIPTION
This allows things like CVEs to be routed to the correct owner in
bugzilla automatically.
