### PR TITLE
Bug 1860142: Adds HealthcheckBrokenCount to forward plugin

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -32,7 +32,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge)
+		metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, HealthcheckBrokenCount, SocketGauge)
 		return f.OnStartup()
 	})
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR is required for the forward plugin to produce the `coredns_forward_healthcheck_broken_count_total ` metric. It was previously missing.

### 2. Which issues (if any) are related?

This is a manual cherry-pick of https://github.com/coredns/coredns/pull/4021 and fixes https://bugzilla.redhat.com/show_bug.cgi?id=1860142

### 3. Which documentation changes (if any) need to be made?
The [forward plugin](https://coredns.io/plugins/forward/) already documents this metic.

### 4. Does this introduce a backward incompatible change or deprecation?
No.

__Note:__ The forward plugin was introduced in OCP v4.5 and therefore this PR should be backported accordingly.

/assign @Miciah @knobunc