### PR TITLE
Upstream #4430: Corrected detection of K8s minor version

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -257,7 +257,7 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (err error) {
 		return err
 	}
 	major, _ := strconv.Atoi(sv.Major)
-	minor, _ := strconv.Atoi(sv.Minor)
+	minor, _ := strconv.Atoi(strings.TrimRight(sv.Minor, "+"))
 	if k.opts.useEndpointSlices && major <= 1 && minor <= 18 {
 		log.Info("watching Endpoints instead of EndpointSlices in k8s versions < 1.19")
 		k.opts.useEndpointSlices = false


### PR DESCRIPTION
Fixes #4428

Signed-off-by: Lars Ekman <lars.g.ekman@est.tech>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

---

This is a manual cherry-pick of https://github.com/coredns/coredns/pull/4430, as a follow up to https://github.com/openshift/coredns/pull/52 & https://github.com/openshift/cluster-dns-operator/pull/244
