### PR TITLE
Bug 1961201: plugin/kubernetes: Treat Endpointslices with a nil ready condition as "ready"

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -128,7 +128,7 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		if end.Conditions.Ready == nil || !*end.Conditions.Ready {
+		if !endpointsliceReady(end.Conditions.Ready) {
 			continue
 		}
 		for _, a := range end.Addresses {
@@ -176,7 +176,7 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		if end.Conditions.Ready == nil || !*end.Conditions.Ready {
+		if !endpointsliceReady(end.Conditions.Ready) {
 			continue
 		}
 		for _, a := range end.Addresses {
@@ -196,6 +196,15 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	*ends = discoveryV1beta1.EndpointSlice{}
 
 	return e, nil
+}
+
+func endpointsliceReady(ready *bool) bool {
+	// Per API docs: a nil value indicates an unknown state. In most cases consumers
+	// should interpret this unknown state as ready.
+	if ready == nil {
+		return true
+	}
+	return *ready
 }
 
 // CopyWithoutSubsets copies e, without the subsets.


### PR DESCRIPTION
**consider nil ready as ready (coredns#4632)** 

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

---

This is a cherry-pick of https://github.com/coredns/coredns/pull/4632.

This commit is in support of https://bugzilla.redhat.com/show_bug.cgi?id=1961201

