### PR TITLE
UPSTREAM: <carry>: openshift: Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Disable dependabot in the openshift fork of CoreDNS