### PR TITLE
Added gcs278 to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ approvers:
   - candita
   - rfredette
   - alebedev87
+  - gcs278
 
 component: DNS
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Adds gcs278 to the OWNERS file

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
N/A