### PR TITLE
OCPBUGS-240: Remove bufsize hardcoding to 2048 on cache upstream refreshes.

### DIFF
--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -160,7 +160,6 @@ func setDo(m *dns.Msg) {
 	o := m.IsEdns0()
 	if o != nil {
 		o.SetDo()
-		o.SetUDPSize(defaultUDPBufSize)
 		return
 	}
 
@@ -172,4 +171,4 @@ func setDo(m *dns.Msg) {
 
 // defaultUDPBufsize is the bufsize the cache plugin uses on outgoing requests that don't
 // have an OPT RR.
-const defaultUDPBufSize = 2048
+const defaultUDPBufSize = 512


### PR DESCRIPTION
UPSTREAM: <carry>: openshift: Remove bufsize hardcoding to 2048 on cache upstream refreshes. Use bufsize as specified in bufsize plugin.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Remove bufsize hardcoding to 2048 on cache upstream refreshes. Use bufsize as specified in bufsize plugin. The code overrides the value of UDP Payload (bufsize) on upstream requests if bufsize was already configured.

When there is no EDNS0 OPT RR, the code now defaults to 512, the value Openshift uses as well as the default value of the bufsize plugin.

This is intended NOT to be a long term carry: remove this carry when https://github.com/coredns/coredns/pull/5671 is in CoreDNS (you'll get obvious merge conflicts anyways).

### 2. Which issues (if any) are related?
https://issues.redhat.com/browse/OCPBUGS-240

### 3. Which documentation changes (if any) need to be made?
N/A

### 4. Does this introduce a backward incompatible change or deprecation?
No