### PR TITLE
OCPBUGS-15755: UPSTREAM: <carry>: openshift: Fix OCPBUGS-15755

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -16,230 +16,15 @@ import (
 	"github.com/miekg/dns"
 )
 
-type cacheTestCase struct {
-	test.Case                    // the expected message coming "out" of cache
-	in                 test.Case // the test message going "in" to cache
-	AuthenticatedData  bool
-	RecursionAvailable bool
-	Truncated          bool
-	shouldCache        bool
-}
-
-var cacheTestCases = []cacheTestCase{
-	{
-		// Test with Authenticated Data bit
-		RecursionAvailable: true, AuthenticatedData: true,
-		Case: test.Case{
-			Qname: "miek.nl.", Qtype: dns.TypeMX,
-			Answer: []dns.RR{
-				test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
-				test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
-			},
-		},
-		in: test.Case{
-			Qname: "miek.nl.", Qtype: dns.TypeMX,
-			Answer: []dns.RR{
-				test.MX("miek.nl.	3601	IN	MX	1 aspmx.l.google.com."),
-				test.MX("miek.nl.	3601	IN	MX	10 aspmx2.googlemail.com."),
-			},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test case sensitivity
-		RecursionAvailable: true, AuthenticatedData: true,
-		Case: test.Case{
-			Qname: "miek.nl.", Qtype: dns.TypeMX,
-			Answer: []dns.RR{
-				test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
-				test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
-			},
-		},
-		in: test.Case{
-			Qname: "mIEK.nL.", Qtype: dns.TypeMX,
-			Answer: []dns.RR{
-				test.MX("miek.nl.	3601	IN	MX	1 aspmx.l.google.com."),
-				test.MX("miek.nl.	3601	IN	MX	10 aspmx2.googlemail.com."),
-			},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test truncated responses don't get cached
-		Truncated: true,
-		Case: test.Case{
-			Qname: "miek.nl.", Qtype: dns.TypeMX,
-			Answer: []dns.RR{test.MX("miek.nl.	1800	IN	MX	1 aspmx.l.google.com.")},
-		},
-		in:          test.Case{},
-		shouldCache: false,
-	},
-	{
-		// Test dns.RcodeNameError cache
-		RecursionAvailable: true,
-		Case: test.Case{
-			Rcode: dns.RcodeNameError,
-			Qname: "example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{
-				test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
-			},
-		},
-		in: test.Case{
-			Rcode: dns.RcodeNameError,
-			Qname: "example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{
-				test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
-			},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test dns.RcodeServerFailure cache
-		RecursionAvailable: true,
-		Case: test.Case{
-			Rcode: dns.RcodeServerFailure,
-			Qname: "example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{},
-		},
-		in: test.Case{
-			Rcode: dns.RcodeServerFailure,
-			Qname: "example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test dns.RcodeNotImplemented cache
-		RecursionAvailable: true,
-		Case: test.Case{
-			Rcode: dns.RcodeNotImplemented,
-			Qname: "example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{},
-		},
-		in: test.Case{
-			Rcode: dns.RcodeNotImplemented,
-			Qname: "example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test cache has separate items for query DO Bit value
-		// This doesn't cache because this RRSIG is expired and previous tests used DO Bit false
-		RecursionAvailable: true,
-		Case: test.Case{
-			Qname: "miek.nl.", Qtype: dns.TypeMX,
-			Do: true,
-			Answer: []dns.RR{
-				test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
-				test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
-				test.RRSIG("miek.nl.	3600	IN	RRSIG	MX 8 2 1800 20160521031301 20160421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
-			},
-		},
-		in: test.Case{
-			Qname: "miek.nl.", Qtype: dns.TypeMX,
-			Do: true,
-			Answer: []dns.RR{
-				test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
-				test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
-				test.RRSIG("miek.nl.	1800	IN	RRSIG	MX 8 2 1800 20160521031301 20160421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
-			},
-		},
-		shouldCache: false,
-	},
-	{
-		// Test DO Bit with a RRSIG that is not expired
-		RecursionAvailable: true,
-		Case: test.Case{
-			Qname: "example.org.", Qtype: dns.TypeMX,
-			Do: true,
-			Answer: []dns.RR{
-				test.MX("example.org.	3600	IN	MX	1 aspmx.l.google.com."),
-				test.MX("example.org.	3600	IN	MX	10 aspmx2.googlemail.com."),
-				test.RRSIG("example.org.	3600	IN	RRSIG	MX 8 2 1800 20170521031301 20170421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
-			},
-		},
-		in: test.Case{
-			Qname: "example.org.", Qtype: dns.TypeMX,
-			Do: true,
-			Answer: []dns.RR{
-				test.MX("example.org.	3600	IN	MX	1 aspmx.l.google.com."),
-				test.MX("example.org.	3600	IN	MX	10 aspmx2.googlemail.com."),
-				test.RRSIG("example.org.	1800	IN	RRSIG	MX 8 2 1800 20170521031301 20170421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
-			},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test negative zone exception
-		in: test.Case{
-			Rcode: dns.RcodeNameError,
-			Qname: "neg-disabled.example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{
-				test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
-			},
-		},
-		Case:        test.Case{},
-		shouldCache: false,
-	},
-	{
-		// Test positive zone exception
-		in: test.Case{
-			Rcode: dns.RcodeSuccess,
-			Qname: "pos-disabled.example.org.", Qtype: dns.TypeA,
-			Answer: []dns.RR{
-				test.A("pos-disabled.example.org. 3600 IN	A	127.0.0.1"),
-			},
-		},
-		Case:        test.Case{},
-		shouldCache: false,
-	},
-	{
-		// Test positive zone exception with negative answer
-		in: test.Case{
-			Rcode: dns.RcodeNameError,
-			Qname: "pos-disabled.example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{
-				test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
-			},
-		},
-		Case: test.Case{
-			Rcode: dns.RcodeNameError,
-			Qname: "pos-disabled.example.org.", Qtype: dns.TypeA,
-			Ns: []dns.RR{
-				test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
-			},
-		},
-		shouldCache: true,
-	},
-	{
-		// Test negative zone exception with positive answer
-		in: test.Case{
-			Rcode: dns.RcodeSuccess,
-			Qname: "neg-disabled.example.org.", Qtype: dns.TypeA,
-			Answer: []dns.RR{
-				test.A("neg-disabled.example.org. 3600 IN	A	127.0.0.1"),
-			},
-		},
-		Case: test.Case{
-			Rcode: dns.RcodeSuccess,
-			Qname: "neg-disabled.example.org.", Qtype: dns.TypeA,
-			Answer: []dns.RR{
-				test.A("neg-disabled.example.org. 3600 IN	A	127.0.0.1"),
-			},
-		},
-		shouldCache: true,
-	},
-}
-
-func cacheMsg(m *dns.Msg, tc cacheTestCase) *dns.Msg {
+func cacheMsg(m *dns.Msg, tc test.Case) *dns.Msg {
 	m.RecursionAvailable = tc.RecursionAvailable
 	m.AuthenticatedData = tc.AuthenticatedData
-	m.Authoritative = true
+	m.CheckingDisabled = tc.CheckingDisabled
+	m.Authoritative = tc.Authoritative
 	m.Rcode = tc.Rcode
 	m.Truncated = tc.Truncated
-	m.Answer = tc.in.Answer
-	m.Ns = tc.in.Ns
+	m.Answer = tc.Answer
+	m.Ns = tc.Ns
 	// m.Extra = tc.in.Extra don't copy Extra, because we don't care and fake EDNS0 DO with tc.Do.
 	return m
 }
@@ -256,57 +41,305 @@ func newTestCache(ttl time.Duration) (*Cache, *ResponseWriter) {
 	return c, crr
 }
 
-func TestCache(t *testing.T) {
+// TestCacheInsertion verifies the insertion of items to the cache.
+func TestCacheInsertion(t *testing.T) {
+	cacheTestCases := []struct {
+		name        string
+		out         test.Case // the expected message coming "out" of cache
+		in          test.Case // the test message going "in" to cache
+		shouldCache bool
+	}{
+		{
+			name: "test ad bit cache",
+			out: test.Case{
+				Qname: "miek.nl.", Qtype: dns.TypeMX,
+				Answer: []dns.RR{
+					test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
+					test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
+				},
+				RecursionAvailable: true,
+				AuthenticatedData:  true,
+			},
+			in: test.Case{
+				Qname: "miek.nl.", Qtype: dns.TypeMX,
+				Answer: []dns.RR{
+					test.MX("miek.nl.	3601	IN	MX	1 aspmx.l.google.com."),
+					test.MX("miek.nl.	3601	IN	MX	10 aspmx2.googlemail.com."),
+				},
+				RecursionAvailable: true,
+				AuthenticatedData:  true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test case sensitivity cache",
+			out: test.Case{
+				Qname: "miek.nl.", Qtype: dns.TypeMX,
+				Answer: []dns.RR{
+					test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
+					test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
+				},
+				RecursionAvailable: true,
+				AuthenticatedData:  true,
+			},
+			in: test.Case{
+				Qname: "mIEK.nL.", Qtype: dns.TypeMX,
+				Answer: []dns.RR{
+					test.MX("miek.nl.	3601	IN	MX	1 aspmx.l.google.com."),
+					test.MX("miek.nl.	3601	IN	MX	10 aspmx2.googlemail.com."),
+				},
+				RecursionAvailable: true,
+				AuthenticatedData:  true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test truncated responses shouldn't cache",
+			in: test.Case{
+				Qname: "miek.nl.", Qtype: dns.TypeMX,
+				Answer:    []dns.RR{test.MX("miek.nl.	1800	IN	MX	1 aspmx.l.google.com.")},
+				Truncated: true,
+			},
+			shouldCache: false,
+		},
+		{
+			name: "test dns.RcodeNameError cache",
+			out: test.Case{
+				Rcode: dns.RcodeNameError,
+				Qname: "example.org.", Qtype: dns.TypeA,
+				Ns: []dns.RR{
+					test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
+				},
+				RecursionAvailable: true,
+			},
+			in: test.Case{
+				Rcode: dns.RcodeNameError,
+				Qname: "example.org.", Qtype: dns.TypeA,
+				Ns: []dns.RR{
+					test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
+				},
+				RecursionAvailable: true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test dns.RcodeServerFailure cache",
+			out: test.Case{
+				Rcode: dns.RcodeServerFailure,
+				Qname: "example.org.", Qtype: dns.TypeA,
+				Ns:                 []dns.RR{},
+				RecursionAvailable: true,
+			},
+			in: test.Case{
+				Rcode: dns.RcodeServerFailure,
+				Qname: "example.org.", Qtype: dns.TypeA,
+				Ns:                 []dns.RR{},
+				RecursionAvailable: true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test dns.RcodeNotImplemented cache",
+			out: test.Case{
+				Rcode: dns.RcodeNotImplemented,
+				Qname: "example.org.", Qtype: dns.TypeA,
+				Ns:                 []dns.RR{},
+				RecursionAvailable: true,
+			},
+			in: test.Case{
+				Rcode: dns.RcodeNotImplemented,
+				Qname: "example.org.", Qtype: dns.TypeA,
+				Ns:                 []dns.RR{},
+				RecursionAvailable: true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test expired RRSIG doesn't cache",
+			in: test.Case{
+				Qname: "miek.nl.", Qtype: dns.TypeMX,
+				Do: true,
+				Answer: []dns.RR{
+					test.MX("miek.nl.	3600	IN	MX	1 aspmx.l.google.com."),
+					test.MX("miek.nl.	3600	IN	MX	10 aspmx2.googlemail.com."),
+					test.RRSIG("miek.nl.	1800	IN	RRSIG	MX 8 2 1800 20160521031301 20160421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
+				},
+				RecursionAvailable: true,
+			},
+			shouldCache: false,
+		},
+		{
+			name: "test DO bit with RRSIG not expired cache",
+			out: test.Case{
+				Qname: "example.org.", Qtype: dns.TypeMX,
+				Do: true,
+				Answer: []dns.RR{
+					test.MX("example.org.	3600	IN	MX	1 aspmx.l.google.com."),
+					test.MX("example.org.	3600	IN	MX	10 aspmx2.googlemail.com."),
+					test.RRSIG("example.org.	3600	IN	RRSIG	MX 8 2 1800 20170521031301 20170421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
+				},
+				RecursionAvailable: true,
+			},
+			in: test.Case{
+				Qname: "example.org.", Qtype: dns.TypeMX,
+				Do: true,
+				Answer: []dns.RR{
+					test.MX("example.org.	3600	IN	MX	1 aspmx.l.google.com."),
+					test.MX("example.org.	3600	IN	MX	10 aspmx2.googlemail.com."),
+					test.RRSIG("example.org.	1800	IN	RRSIG	MX 8 2 1800 20170521031301 20170421031301 12051 miek.nl. lAaEzB5teQLLKyDenatmyhca7blLRg9DoGNrhe3NReBZN5C5/pMQk8Jc u25hv2fW23/SLm5IC2zaDpp2Fzgm6Jf7e90/yLcwQPuE7JjS55WMF+HE LEh7Z6AEb+Iq4BWmNhUz6gPxD4d9eRMs7EAzk13o1NYi5/JhfL6IlaYy qkc="),
+				},
+				RecursionAvailable: true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test CD bit cache",
+			out: test.Case{
+				Rcode: dns.RcodeSuccess,
+				Qname: "dnssec-failed.org.",
+				Qtype: dns.TypeA,
+				Answer: []dns.RR{
+					test.A("dnssec-failed.org. 3600 IN	A	127.0.0.1"),
+				},
+				CheckingDisabled: true,
+			},
+			in: test.Case{
+				Rcode: dns.RcodeSuccess,
+				Qname: "dnssec-failed.org.",
+				Answer: []dns.RR{
+					test.A("dnssec-failed.org. 3600 IN	A	127.0.0.1"),
+				},
+				Qtype:            dns.TypeA,
+				CheckingDisabled: true,
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test negative zone exception shouldn't cache",
+			in: test.Case{
+				Rcode: dns.RcodeNameError,
+				Qname: "neg-disabled.example.org.", Qtype: dns.TypeA,
+				Ns: []dns.RR{
+					test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
+				},
+			},
+			shouldCache: false,
+		},
+		{
+			name: "test positive zone exception shouldn't cache",
+			in: test.Case{
+				Rcode: dns.RcodeSuccess,
+				Qname: "pos-disabled.example.org.", Qtype: dns.TypeA,
+				Answer: []dns.RR{
+					test.A("pos-disabled.example.org. 3600 IN	A	127.0.0.1"),
+				},
+			},
+			shouldCache: false,
+		},
+		{
+			name: "test positive zone exception with negative answer cache",
+			in: test.Case{
+				Rcode: dns.RcodeNameError,
+				Qname: "pos-disabled.example.org.", Qtype: dns.TypeA,
+				Ns: []dns.RR{
+					test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
+				},
+			},
+			out: test.Case{
+				Rcode: dns.RcodeNameError,
+				Qname: "pos-disabled.example.org.", Qtype: dns.TypeA,
+				Ns: []dns.RR{
+					test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
+				},
+			},
+			shouldCache: true,
+		},
+		{
+			name: "test negative zone exception with positive answer cache",
+			in: test.Case{
+				Rcode: dns.RcodeSuccess,
+				Qname: "neg-disabled.example.org.", Qtype: dns.TypeA,
+				Answer: []dns.RR{
+					test.A("neg-disabled.example.org. 3600 IN	A	127.0.0.1"),
+				},
+			},
+			out: test.Case{
+				Rcode: dns.RcodeSuccess,
+				Qname: "neg-disabled.example.org.", Qtype: dns.TypeA,
+				Answer: []dns.RR{
+					test.A("neg-disabled.example.org. 3600 IN	A	127.0.0.1"),
+				},
+			},
+			shouldCache: true,
+		},
+	}
 	now, _ := time.Parse(time.UnixDate, "Fri Apr 21 10:51:21 BST 2017")
 	utc := now.UTC()
 
-	c, crr := newTestCache(maxTTL)
+	for _, tc := range cacheTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a new cache every time to prevent accidental comparison with a previous item.
+			c, crr := newTestCache(maxTTL)
 
-	for n, tc := range cacheTestCases {
-		m := tc.in.Msg()
-		m = cacheMsg(m, tc)
+			m := tc.in.Msg()
+			m = cacheMsg(m, tc.in)
 
-		state := request.Request{W: &test.ResponseWriter{}, Req: m}
+			state := request.Request{W: &test.ResponseWriter{}, Req: m}
 
-		mt, _ := response.Typify(m, utc)
-		valid, k := key(state.Name(), m, mt, state.Do())
+			mt, _ := response.Typify(m, utc)
+			valid, k := key(state.Name(), m, mt, state.Do(), state.Req.CheckingDisabled)
 
-		if valid {
-			crr.set(m, k, mt, c.pttl)
-		}
-
-		i := c.getIgnoreTTL(time.Now().UTC(), state, "dns://:53")
-		ok := i != nil
-
-		if !tc.shouldCache && ok {
-			t.Errorf("Test %d: Cached message that should not have been cached: %s", n, state.Name())
-			continue
-		}
-		if tc.shouldCache && !ok {
-			t.Errorf("Test %d: Did not cache message that should have been cached: %s", n, state.Name())
-			continue
-		}
-
-		if ok {
-			resp := i.toMsg(m, time.Now().UTC(), state.Do(), m.AuthenticatedData)
-
-			if err := test.Header(tc.Case, resp); err != nil {
-				t.Logf("Cache %v", resp)
-				t.Error(err)
-				continue
+			if valid {
+				// Insert cache entry
+				crr.set(m, k, mt, c.pttl)
 			}
 
-			if err := test.Section(tc.Case, test.Answer, resp.Answer); err != nil {
-				t.Logf("Cache %v -- %v", test.Answer, resp.Answer)
-				t.Error(err)
+			// Attempt to retrieve cache entry
+			i := c.getIgnoreTTL(time.Now().UTC(), state, "dns://:53")
+			found := i != nil
+
+			if !tc.shouldCache && found {
+				t.Fatalf("Cached message that should not have been cached: %s", state.Name())
 			}
-			if err := test.Section(tc.Case, test.Ns, resp.Ns); err != nil {
-				t.Error(err)
+			if tc.shouldCache && !found {
+				t.Fatalf("Did not cache message that should have been cached: %s", state.Name())
 			}
-			if err := test.Section(tc.Case, test.Extra, resp.Extra); err != nil {
-				t.Error(err)
+
+			if found {
+				resp := i.toMsg(m, time.Now().UTC(), state.Do(), m.AuthenticatedData)
+
+				// TODO: If we incorporate these individual checks into the
+				//       test.Header function, we can eliminate them from here.
+				// Cache entries are always Authoritative.
+				if resp.Authoritative != true {
+					t.Error("Expected Authoritative Answer bit to be true, but was false")
+				}
+				if resp.AuthenticatedData != tc.out.AuthenticatedData {
+					t.Errorf("Expected Authenticated Data bit to be %t, but got %t", tc.out.AuthenticatedData, resp.AuthenticatedData)
+				}
+				if resp.RecursionAvailable != tc.out.RecursionAvailable {
+					t.Errorf("Expected Recursion Available bit to be %t, but got %t", tc.out.RecursionAvailable, resp.RecursionAvailable)
+				}
+				if resp.CheckingDisabled != tc.out.CheckingDisabled {
+					t.Errorf("Expected Checking Disabled bit to be %t, but got %t", tc.out.CheckingDisabled, resp.CheckingDisabled)
+				}
+
+				if err := test.Header(tc.out, resp); err != nil {
+					t.Logf("Cache %v", resp)
+					t.Error(err)
+				}
+				if err := test.Section(tc.out, test.Answer, resp.Answer); err != nil {
+					t.Logf("Cache %v -- %v", test.Answer, resp.Answer)
+					t.Error(err)
+				}
+				if err := test.Section(tc.out, test.Ns, resp.Ns); err != nil {
+					t.Error(err)
+				}
+				if err := test.Section(tc.out, test.Extra, resp.Extra); err != nil {
+					t.Error(err)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -668,7 +701,7 @@ func TestCacheWildcardMetadata(t *testing.T) {
 	if c.pcache.Len() != 1 {
 		t.Errorf("Msg should have been cached")
 	}
-	_, k := key(qname, w.Msg, response.NoError, state.Do())
+	_, k := key(qname, w.Msg, response.NoError, state.Do(), state.Req.CheckingDisabled)
 	i, _ := c.pcache.Get(k)
 	if i.(*item).wildcard != wildcard {
 		t.Errorf("expected wildcard response to enter cache with cache item's wildcard = %q, got %q", wildcard, i.(*item).wildcard)
@@ -728,7 +761,129 @@ func TestCacheKeepTTL(t *testing.T) {
 	}
 }
 
-// wildcardMetadataBackend mocks a backend that reponds with a response for qname synthesized by wildcard
+// TestCacheSeparation verifies whether the cache maintains separation for specific DNS query types and options.
+func TestCacheSeparation(t *testing.T) {
+	now, _ := time.Parse(time.UnixDate, "Fri Apr 21 10:51:21 BST 2017")
+	utc := now.UTC()
+
+	testCases := []struct {
+		name         string
+		initial      test.Case
+		query        test.Case
+		expectCached bool // if a cache entry should be found before inserting
+	}{
+		{
+			name: "query type should be unique",
+			initial: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+			},
+			query: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeAAAA,
+			},
+		},
+		{
+			name: "DO bit should be unique",
+			initial: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+			},
+			query: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+				Do:    true,
+			},
+		},
+		{
+			name: "CD bit should be unique",
+			initial: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+			},
+			query: test.Case{
+				Qname:            "example.org.",
+				Qtype:            dns.TypeA,
+				CheckingDisabled: true,
+			},
+		},
+		{
+			name: "CD bit and DO bit should be unique",
+			initial: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+			},
+			query: test.Case{
+				Qname:            "example.org.",
+				Qtype:            dns.TypeA,
+				CheckingDisabled: true,
+				Do:               true,
+			},
+		},
+		{
+			name: "CD bit, DO bit, and query type should be unique",
+			initial: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+			},
+			query: test.Case{
+				Qname:            "example.org.",
+				Qtype:            dns.TypeMX,
+				CheckingDisabled: true,
+				Do:               true,
+			},
+		},
+		{
+			name: "authoritative answer bit should NOT be unique",
+			initial: test.Case{
+				Qname: "example.org.",
+				Qtype: dns.TypeA,
+			},
+			query: test.Case{
+				Qname:         "example.org.",
+				Qtype:         dns.TypeA,
+				Authoritative: true,
+			},
+			expectCached: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			crr := &ResponseWriter{ResponseWriter: nil, Cache: c}
+
+			// Insert initial cache entry
+			m := tc.initial.Msg()
+			m = cacheMsg(m, tc.initial)
+			state := request.Request{W: &test.ResponseWriter{}, Req: m}
+
+			mt, _ := response.Typify(m, utc)
+			valid, k := key(state.Name(), m, mt, state.Do(), state.Req.CheckingDisabled)
+
+			if valid {
+				// Insert cache entry
+				crr.set(m, k, mt, c.pttl)
+			}
+
+			// Attempt to retrieve cache entry
+			m = tc.query.Msg()
+			m = cacheMsg(m, tc.query)
+			state = request.Request{W: &test.ResponseWriter{}, Req: m}
+
+			item := c.getIgnoreTTL(time.Now().UTC(), state, "dns://:53")
+			found := item != nil
+
+			if !tc.expectCached && found {
+				t.Fatal("Found cache message should that should not exist prior to inserting")
+			}
+			if tc.expectCached && !found {
+				t.Fatal("Did not find cache message that should exist prior to inserting")
+			}
+		})
+	}
+}
+
+// wildcardMetadataBackend mocks a backend that responds with a response for qname synthesized by wildcard
 // and sets the zone/wildcard metadata value
 func wildcardMetadataBackend(qname, wildcard string) plugin.Handler {
 	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -29,15 +29,19 @@ func (p RRSet) Less(i, j int) bool { return p[i].String() < p[j].String() }
 // Case represents a test case that encapsulates various data from a query and response.
 // Note that is the TTL of a record is 303 we don't compare it with the TTL.
 type Case struct {
-	Qname             string
-	Qtype             uint16
-	Rcode             int
-	Do                bool
-	AuthenticatedData bool
-	Answer            []dns.RR
-	Ns                []dns.RR
-	Extra             []dns.RR
-	Error             error
+	Qname              string
+	Qtype              uint16
+	Rcode              int
+	Do                 bool
+	CheckingDisabled   bool
+	RecursionAvailable bool
+	AuthenticatedData  bool
+	Authoritative      bool
+	Truncated          bool
+	Answer             []dns.RR
+	Ns                 []dns.RR
+	Extra              []dns.RR
+	Error              error
 }
 
 // Msg returns a *dns.Msg embedded in c.


### PR DESCRIPTION
Cherry-Pick of https://github.com/coredns/coredns/pull/6354 which fixes OCPBUGS-15755.

plugin/cache: key cache on Checking Disabled (CD) bit

Key the cache on CD bit, which effectively separates the entries for queries with CD disabled or enabled.
