### PR TITLE
[release-4.16] OCPBUGS-37078: UPSTREAM: <carry>: openshift: Bump the version of ocp_dnsnameresolver external plugin

### DIFF
--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -57,6 +57,5 @@ import (
 	_ "github.com/coredns/coredns/plugin/view"
 	_ "github.com/coredns/coredns/plugin/whoami"
 
-	
 	_ "github.com/openshift/coredns-ocp-dnsnameresolver"
 )

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/infobloxopen/go-trees v0.0.0-20200715205103-96a057b8dfb9
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/miekg/dns v1.1.55
-	github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240326070009-fc0f61729b14
+	github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240805163609-83fc794497bc
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.5.0
 	github.com/openzipkin/zipkin-go v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/openshift/api v0.0.0-20231017161003-8f2e18642ccb h1:ez6Jrs2pSGMdPMR4l
 github.com/openshift/api v0.0.0-20231017161003-8f2e18642ccb/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6 h1:3wgEtuYbZ76oOXjhSJ2p1m0lftgghK0XlR9guG2aKhA=
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6/go.mod h1:Fkn7VRruQ4KwNGeaUmi9QgqLk/d7U6cj+UiP8b+0hiQ=
-github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240326070009-fc0f61729b14 h1:aDYudMP8/wHNGPOUAiMbTvtlJhIDalAvJ7Q6PEt1LQg=
-github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240326070009-fc0f61729b14/go.mod h1:0x4AUO3QDo9jPwY7Gh+nGEFU9q0Xnv5aM0EF40GYBGo=
+github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240805163609-83fc794497bc h1:6Y2w4D8A8dtQ06+oWnDpdWep1kmyMH4nrxXVaVoyVww=
+github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240805163609-83fc794497bc/go.mod h1:0x4AUO3QDo9jPwY7Gh+nGEFU9q0Xnv5aM0EF40GYBGo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=

--- a/vendor/github.com/openshift/coredns-ocp-dnsnameresolver/.ci-operator.yaml
+++ b/vendor/github.com/openshift/coredns-ocp-dnsnameresolver/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.21

--- a/vendor/github.com/openshift/coredns-ocp-dnsnameresolver/Dockerfile.upstream
+++ b/vendor/github.com/openshift/coredns-ocp-dnsnameresolver/Dockerfile.upstream
@@ -1,0 +1,10 @@
+FROM golang:1.21 as builder
+WORKDIR /go/src/github.com/coredns/coredns-ocp-dnsnameresolver
+COPY . .
+
+RUN make build-coredns ARGS="upstream"
+
+FROM gcr.io/distroless/base-debian12:latest
+COPY --from=builder /go/src/github.com/coredns/coredns-ocp-dnsnameresolver/coredns /usr/bin/
+
+ENTRYPOINT ["/usr/bin/coredns"]

--- a/vendor/github.com/openshift/coredns-ocp-dnsnameresolver/Makefile
+++ b/vendor/github.com/openshift/coredns-ocp-dnsnameresolver/Makefile
@@ -13,7 +13,7 @@ test: ## Run go test against code
 
 .PHONY: build-coredns
 build-coredns: ## Build coredns using the local branch of coredns-ocp-dnsnameresolver
-	hack/build-coredns.sh
+	hack/build-coredns.sh $(ARGS)
 
 .PHONY: clean
 clean:
@@ -22,6 +22,7 @@ clean:
 
 CONTAINER_ENGINE ?= podman
 CONTAINER_IMAGE ?= coredns
+DOCKERFILE_PATH ?= Dockerfile
 
 .PHONY: local-image
 local-image:
@@ -29,13 +30,13 @@ ifndef CONTAINER_IMAGE
 	echo "  Please pass a container image ... "
 else ifeq ($(CONTAINER_ENGINE), buildah)
 	echo "  - Building with buildah ... "
-	buildah bud -t $(CONTAINER_IMAGE) .
+	buildah bud -t $(CONTAINER_IMAGE) -f $(DOCKERFILE_PATH) .
 else ifeq ($(CONTAINER_ENGINE), docker)
 	echo "  - Building with docker ... "
-	docker build -t $(CONTAINER_IMAGE) .
+	docker build -t $(CONTAINER_IMAGE) -f $(DOCKERFILE_PATH) .
 else ifeq ($(CONTAINER_ENGINE), podman)
 	echo "  - Building with podman ... "
-	podman build -t $(CONTAINER_IMAGE) .
+	podman build -t $(CONTAINER_IMAGE) -f $(DOCKERFILE_PATH) .
 else
 	echo "  Please pass a container engine ... "
 endif

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -367,7 +367,7 @@ github.com/openshift/client-go/network/informers/externalversions/network/v1
 github.com/openshift/client-go/network/informers/externalversions/network/v1alpha1
 github.com/openshift/client-go/network/listers/network/v1
 github.com/openshift/client-go/network/listers/network/v1alpha1
-# github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240326070009-fc0f61729b14
+# github.com/openshift/coredns-ocp-dnsnameresolver v0.0.0-20240805163609-83fc794497bc
 ## explicit; go 1.21
 github.com/openshift/coredns-ocp-dnsnameresolver
 # github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492


### PR DESCRIPTION
This PR bumps the version of the external plugin ocp_dnsnameresolver for release-4.16.
Following commands were run:

```
go get github.com/openshift/coredns-ocp-dnsnameresolver@release-4.16
go mod tidy
go mod vendor

go generate
```