### PR TITLE
[release-4.16] OCPBUGS-60008: UPSTREAM: 7083: Fix failing unit test TestZoneExternalCNAMELookupWithProxy

### DIFF
--- a/test/example_test.go
+++ b/test/example_test.go
@@ -11,6 +11,6 @@ short   1    IN  A      127.0.0.3
 
 *.w     3600 IN  TXT    "Wildcard"
 a.b.c.w      IN  TXT    "Not a wildcard"
-cname        IN  CNAME  www.example.net.
+cname        IN  CNAME  h.gtld-servers.net.
 service      IN  SRV    8080 10 10 @
 `


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fix the failing unit test `TestZoneExternalCNAMELookupWithProxy` by replacing [www.example.net](http://www.example.net/) with [h.gtld-servers.net.](h.gtld-servers.net.)
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
NA
### 4. Does this introduce a backward incompatible change or deprecation?
