### PR TITLE
OCPBUGS-76989: CVE-2025-68151 openshift4/ose-coredns-rhel9: CoreDNS DoS via unbounded connections and oversized messages [openshift-4.20]

### DIFF
--- a/plugin/grpc/proxy.go
+++ b/plugin/grpc/proxy.go
@@ -3,6 +3,8 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -14,6 +16,20 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	// maxDNSMessageBytes is the maximum size of a DNS message on the wire.
+	maxDNSMessageBytes = dns.MaxMsgSize
+
+	// maxProtobufPayloadBytes accounts for protobuf overhead.
+	// Field tag=1 (1 byte) + length varint for 65535 (3 bytes) = 4 bytes total
+	maxProtobufPayloadBytes = maxDNSMessageBytes + 4
+)
+
+var (
+	// ErrDNSMessageTooLarge is returned when a DNS message exceeds the maximum allowed size.
+	ErrDNSMessageTooLarge = errors.New("dns message exceeds size limit")
 )
 
 // Proxy defines an upstream host.
@@ -37,7 +53,16 @@ func newProxy(addr string, tlsConfig *tls.Config) (*Proxy, error) {
 		p.dialOpts = append(p.dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	conn, err := grpc.Dial(p.addr, p.dialOpts...)
+	// Cap send/recv sizes to avoid oversized messages.
+	// Note: gRPC size limits apply to the serialized protobuf message size.
+	p.dialOpts = append(p.dialOpts,
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxProtobufPayloadBytes),
+			grpc.MaxCallSendMsgSize(maxProtobufPayloadBytes),
+		),
+	)
+
+	conn, err := grpc.NewClient(p.addr, p.dialOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,6 +80,10 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 		return nil, err
 	}
 
+	if err := validateDNSSize(msg); err != nil {
+		return nil, err
+	}
+
 	reply, err := p.client.Query(ctx, &pb.DnsPacket{Msg: msg})
 	if err != nil {
 		// if not found message, return empty message with NXDomain code
@@ -64,8 +93,14 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 		}
 		return nil, err
 	}
+	wire := reply.GetMsg()
+
+	if err := validateDNSSize(wire); err != nil {
+		return nil, err
+	}
+
 	ret := new(dns.Msg)
-	if err := ret.Unpack(reply.Msg); err != nil {
+	if err := ret.Unpack(wire); err != nil {
 		return nil, err
 	}
 
@@ -79,4 +114,12 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 	RequestDuration.WithLabelValues(p.addr).Observe(time.Since(start).Seconds())
 
 	return ret, nil
+}
+
+func validateDNSSize(data []byte) error {
+	l := len(data)
+	if l > maxDNSMessageBytes {
+		return fmt.Errorf("%w: %d bytes (limit %d)", ErrDNSMessageTooLarge, l, maxDNSMessageBytes)
+	}
+	return nil
 }


### PR DESCRIPTION
Add DNS wire size validation for requests/replies. Limit gRPC recv/send via default call options, accounting necessary framing/protobuf overhead. An error is returned for oversized messages. Add test.
