### PR TITLE
NE-2760: Update base image references to 5.0 for DEFAULT:PQ crypto-policy

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/coredns/coredns
 COPY . .
 RUN GO111MODULE=on GOFLAGS=-mod=vendor go build -o coredns .
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/coredns/coredns/coredns /usr/bin/
 
 ENTRYPOINT ["/usr/bin/coredns"]


### PR DESCRIPTION
## Summary

- Update `Dockerfile.ocp` builder image from `rhel-9-golang-1.25-openshift-4.22` to `rhel-9-golang-1.26-openshift-5.0`
- Update `Dockerfile.ocp` base image from `ocp/4.22:base-rhel9` to `ocp/5.0:base-rhel9`
- Update `.ci-operator.yaml` build root tag to `rhel-9-release-golang-1.26-openshift-5.0`

The 5.0 base image includes the `DEFAULT:PQ` crypto-policy configuration from https://github.com/openshift/images/pull/230, enabling post-quantum cryptography support.

Consistent with references used by other NE repos on release-4.23 (e.g., cluster-ingress-operator).

## Test plan

- [ ] CI e2e tests pass with updated base image
- [ ] Verify coredns binary runs correctly on the new base image with DEFAULT:PQ policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)